### PR TITLE
Prettier boarder

### DIFF
--- a/peek.el
+++ b/peek.el
@@ -66,7 +66,7 @@
   :type 'natnum
   :group 'peek)
 
-(defcustom peek-overlay-border-symbol ?-
+(defcustom peek-overlay-border-symbol ?\N{BOX DRAWINGS LIGHT HORIZONTAL}
   "Specify symbol for peek overlay window border."
   :type 'character
   :group 'peek)


### PR DESCRIPTION
* peek.el (peek-overlay-border-symbol): Use Unicode character.

___

顺便一提, 行内注释一般是句末加两个空格, 再加一个分号:

```lisp
(say 'hello)  ; Comment here.
```